### PR TITLE
Added User Model Table Definition

### DIFF
--- a/src/main/java/edu/neu/cs4500/models/User.java
+++ b/src/main/java/edu/neu/cs4500/models/User.java
@@ -1,15 +1,27 @@
 package edu.neu.cs4500.models;
 
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
 /**
  * Created by Michael Goodnow on 2019-01-23.
  */
 
+@Entity
+@Table(name="users")
 public class User {
+	@Id
+	@GeneratedValue(strategy=GenerationType.IDENTITY)
 	private Integer id;
 	private String username;
 	private String password;
 	private String firstName;
 	private String lastName;
+
+	public User() {
+	}
 
 	public User(Integer id, String username, String password, String firstName, String lastName) {
 		this.id = id;

--- a/src/main/resources/sql/create_user_table.sql
+++ b/src/main/resources/sql/create_user_table.sql
@@ -1,0 +1,10 @@
+DROP TABLE IF EXISTS users;
+CREATE TABLE users (
+  id int(11) NOT NULL AUTO_INCREMENT,
+  username varchar(255) DEFAULT NULL,
+  password varchar(255) DEFAULT NULL,
+  first_name varchar(255) DEFAULT NULL,
+  last_name varchar(255) DEFAULT NULL,
+  role varchar(255) DEFAULT NULL,
+  PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;


### PR DESCRIPTION
The changed in this PR are as follows:

- Modified `User` model to be JPA-compliant, destination SQL Table is `users`
- Added sample SQL command for `users` table creation. Code obtained from Prof's repo