### PR TITLE
Modifying gitignore for .vscode/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 /target/
 !.mvn/wrapper/maven-wrapper.jar
+.vscode/
 
 ### STS ###
 .apt_generated


### PR DESCRIPTION
`.gitignore` is modified for the following reasons:

- Prevents `.vscode` directory for VS Code from ever being committed.