### PR TITLE
Skeleton for Estimate, Frequency Enum, and SubscriptionDiscount

### DIFF
--- a/src/main/java/edu/neu/cs4500/models/Estimate.java
+++ b/src/main/java/edu/neu/cs4500/models/Estimate.java
@@ -1,0 +1,22 @@
+package edu.neu.cs4500.models;
+
+import java.util.List;
+
+//import javax.persistence.*;
+
+//@Entity
+//@Table(name="estimates")
+public class Estimate {
+
+    //@Id
+    //@GeneratedValue(strategy=GenerationType.IDENTITY)
+    private Integer id;
+
+    private float estimate;
+    private float baseprice;
+    private Frequency baseFrequency;
+    private boolean subscription;
+    private Frequency subscriptionFrequency;
+    private Frequency deliveryFrequency;
+
+}

--- a/src/main/java/edu/neu/cs4500/models/Frequency.java
+++ b/src/main/java/edu/neu/cs4500/models/Frequency.java
@@ -1,0 +1,25 @@
+package edu.neu.cs4500.models;
+
+public enum Frequency {
+    ONETIME ("Onetime"),
+    HOURLY ("Hourly"),
+    DAILY ("Daily"),
+    BIWEEKLY ("Biweekly"),
+    MONTHLY ("Monthly"),
+    YEARLY ("Yearly"),
+    WEEKDAY ("Weekday"), 
+    WEEKEND ("Weekend"),
+    EMERGENCY ("Emergency"),
+    HOLIDAY ("Holiday");
+
+    private final String name;
+
+    private Frequency(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/src/main/java/edu/neu/cs4500/models/SubscriptionDiscount.java
+++ b/src/main/java/edu/neu/cs4500/models/SubscriptionDiscount.java
@@ -1,0 +1,16 @@
+package edu.neu.cs4500.models;
+
+//import javax.persistence.*;
+
+//@Entity
+//@Table(name="subscription_discount")
+public class SubscriptionDiscount {
+
+    //@Id
+    //@GeneratedValue(strategy=GenerationType.IDENTITY)
+    private Integer id;
+
+    private float discount;
+    private Frequency frequency;
+    private boolean flat;
+}


### PR DESCRIPTION
This branch added features as follows:

- Added `Estimate` model for Provider Estimates
- Added `Frequency` enum with overridden `toString()` for use with `Estimate`s
- Added `SubscriptionDiscount` model for use with `Estimate`s

The classes/enums created are not complete, they will be added in upcoming branches. 

(A6 does not care about JPA... but added related statements in comments to save typing for future assignments.)