### PR TITLE
`getDiscount()` in Estimate Objects

### DIFF
--- a/src/main/java/edu/neu/cs4500/models/Estimate.java
+++ b/src/main/java/edu/neu/cs4500/models/Estimate.java
@@ -19,4 +19,65 @@ public class Estimate {
     private Frequency subscriptionFrequency;
     private Frequency deliveryFrequency;
 
+    public Estimate(float estimate, float baseprice, Frequency baseFrequency, 
+            boolean subscription, Frequency subscriptionFrequency, Frequency deliveryFrequency) {
+        this.estimate = estimate;
+        this.baseprice = baseprice;
+        this.baseFrequency = baseFrequency;
+        this.subscription = subscription;
+        this.subscriptionFrequency = subscriptionFrequency;
+        this.deliveryFrequency = deliveryFrequency;
+    }
+            
+    public Integer getId() {
+        return id;
+    }
+
+    public float getEstimate() {
+        return estimate;
+    }
+
+    public float getBaseprice() {
+        return baseprice;
+    }
+
+    public Frequency getBaseFrequency() {
+        return baseFrequency;
+    }
+
+    public boolean getSubscription() {
+        return subscription;
+    }
+
+    public Frequency getSubscriptionFrequency() {
+        return subscriptionFrequency;
+    }
+
+    public Frequency getDeliveryFrequency() {
+        return deliveryFrequency;
+    }
+
+    public void setEstimate(float estimate) {
+        this.estimate = estimate;
+    }
+
+    public void setBaseprice(float baseprice) {
+        this.baseprice = baseprice;
+    }
+
+    public void setBaseFrequency(Frequency baseFrequency) {
+        this.baseFrequency = baseFrequency;
+    }
+
+    public void setSubscription(boolean subscription) {
+        this.subscription = subscription;
+    }
+
+    public void setSubscriptionFrequency(Frequency subscriptionFrequency) {
+        this.subscriptionFrequency = subscriptionFrequency;
+    }
+
+    public void setDeliveryFrequency(Frequency deliveryFrequency) {
+        this.deliveryFrequency = deliveryFrequency;
+    }
 }

--- a/src/main/java/edu/neu/cs4500/models/Estimate.java
+++ b/src/main/java/edu/neu/cs4500/models/Estimate.java
@@ -95,6 +95,6 @@ public class Estimate {
                 accumulateDiscount = accumulateDiscount + this.baseprice * discount.getDiscount();
             }
         }
-        return accumulateDiscount
+        return accumulateDiscount;
     }
 }

--- a/src/main/java/edu/neu/cs4500/models/Estimate.java
+++ b/src/main/java/edu/neu/cs4500/models/Estimate.java
@@ -1,5 +1,6 @@
 package edu.neu.cs4500.models;
 
+import java.util.HashMap;
 import java.util.List;
 
 //import javax.persistence.*;
@@ -79,5 +80,21 @@ public class Estimate {
 
     public void setDeliveryFrequency(Frequency deliveryFrequency) {
         this.deliveryFrequency = deliveryFrequency;
+    }
+
+    /**
+     * Calculate subscription discount of the estimate, for a given discount.
+     */
+    public float getDiscount(List<SubscriptionDiscount> discounts) {
+        float accumulateDiscount = 0.0f;
+        for (SubscriptionDiscount discount : discounts) {
+            if (discount.getFrequency() == this.subscriptionFrequency && discount.isFlat()) {
+                accumulateDiscount += discount.getDiscount();
+            }
+            if (discount.getFrequency() == this.subscriptionFrequency && !!discount.isFlat()) {
+                accumulateDiscount = accumulateDiscount + this.baseprice * discount.getDiscount();
+            }
+        }
+        return accumulateDiscount
     }
 }

--- a/src/main/java/edu/neu/cs4500/models/SubscriptionDiscount.java
+++ b/src/main/java/edu/neu/cs4500/models/SubscriptionDiscount.java
@@ -14,6 +14,12 @@ public class SubscriptionDiscount {
     private Frequency frequency;
     private boolean flat;
 
+    public SubscriptionDiscount(float discount, Frequency frequency, boolean flat) {
+        this.discount = discount;
+        this.frequency = frequency;
+        this.flat = flat;
+    }
+
     public Integer getId() {
         return id;
     }

--- a/src/main/java/edu/neu/cs4500/models/SubscriptionDiscount.java
+++ b/src/main/java/edu/neu/cs4500/models/SubscriptionDiscount.java
@@ -13,4 +13,32 @@ public class SubscriptionDiscount {
     private float discount;
     private Frequency frequency;
     private boolean flat;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public float getDiscount() {
+        return discount;
+    }
+
+    public Frequency getFrequency() {
+        return frequency;
+    }
+
+    public boolean isFlat() {
+        return flat;
+    }
+
+    public void setDiscount(float discount) {
+        this.discount = discount;
+    }
+
+    public void setFrequency(Frequency frequency) {
+        this.frequency = frequency;
+    }
+
+    public void setFlat(boolean flat) {
+        this.flat = flat;
+    }
 }


### PR DESCRIPTION
This PR has the following changes:

- Added getters and setters for `SubscriptionDiscount` and `Estimate` classes
  - `id` setters are not yet implemented (assuming JPA will handle them in the future)
- Implemented `getDiscount()`, which given a list of `SubscriptionDiscount`s, adds up all applicable discounts and return the final discount value, in `float`.