### PR TITLE
Discount tests, Bug fixes

### DIFF
--- a/src/main/java/edu/neu/cs4500/models/Estimate.java
+++ b/src/main/java/edu/neu/cs4500/models/Estimate.java
@@ -92,11 +92,11 @@ public class Estimate {
     public float getDiscount(List<SubscriptionDiscount> discounts) {
         float accumulateDiscount = 0.0f;
         for (SubscriptionDiscount discount : discounts) {
-            if (discount.getFrequency() == this.subscriptionFrequency && discount.isFlat()) {
+            if (discount.getFrequency().equals(this.subscriptionFrequency) && discount.isFlat()) {
                 accumulateDiscount += discount.getDiscount();
             }
-            if (discount.getFrequency() == this.subscriptionFrequency && !!discount.isFlat()) {
-                accumulateDiscount = accumulateDiscount + this.baseprice * discount.getDiscount();
+            if (discount.getFrequency().equals(this.subscriptionFrequency) && !discount.isFlat()) {
+                accumulateDiscount = accumulateDiscount + this.baseprice * 0.01f * discount.getDiscount();
             }
         }
         return accumulateDiscount;

--- a/src/test/java/SubscriptionEstimateDiscountTest.java
+++ b/src/test/java/SubscriptionEstimateDiscountTest.java
@@ -18,6 +18,7 @@ public class SubscriptionEstimateDiscountTest {
     private SubscriptionDiscount discount1 = new SubscriptionDiscount();
     private SubscriptionDiscount discount2 = new SubscriptionDiscount();
     private SubscriptionDiscount discount3 = new SubscriptionDiscount();
+    private SubscriptionDiscount discount4 = new SubscriptionDiscount();
 
     @BeforeEach
     public void init() {
@@ -72,4 +73,20 @@ public class SubscriptionEstimateDiscountTest {
         assertEquals(0.0f, estimate1.getDiscount(discountList));
     }
 
+    // Testing multiple discounts 
+    @Test
+    public void testMultipleDiscountsSum() {
+        discount3.setDiscount(10.0f);
+        discount3.setFlat(true);
+        discount3.setFrequency(Frequency.MONTHLY);
+
+        discount4.setDiscount(20.0f);
+        discount4.setFlat(true);
+        discount4.setFrequency(Frequency.MONTHLY);
+
+        discountList.add(discount3);
+        discountList.add(discount4);
+
+        assertEquals(30.0f, estimate1.getDiscount(discountList));
+    }
 }

--- a/src/test/java/SubscriptionEstimateDiscountTest.java
+++ b/src/test/java/SubscriptionEstimateDiscountTest.java
@@ -22,7 +22,7 @@ public class SubscriptionEstimateDiscountTest {
     @BeforeEach
     public void init() {
         estimate1.setBaseprice(200.00f);
-        estimate1.setBaseFrequency(Frequency.MONTHLY);
+        estimate1.setSubscriptionFrequency(Frequency.MONTHLY);
         discountList.clear();
     }
 
@@ -47,5 +47,17 @@ public class SubscriptionEstimateDiscountTest {
         discountList.add(discount0_pct);
 
         assertEquals(0.0f, estimate1.getDiscount(discountList));
+    }
+
+    // Testing matching and nonmatching subscription frequencies
+    @Test
+    public void testMatchingSubscriptionFrequency() {
+        discount1.setDiscount(10.0f);
+        discount1.setFlat(true);
+        discount1.setFrequency(Frequency.MONTHLY);
+
+        discountList.add(discount1);
+
+        assertEquals(10.0f, estimate1.getDiscount(discountList));
     }
 }

--- a/src/test/java/SubscriptionEstimateDiscountTest.java
+++ b/src/test/java/SubscriptionEstimateDiscountTest.java
@@ -60,4 +60,16 @@ public class SubscriptionEstimateDiscountTest {
 
         assertEquals(10.0f, estimate1.getDiscount(discountList));
     }
+
+    @Test
+    public void testNonMatchingSubscriptionFrequency() {
+        discount2.setDiscount(10.0f);
+        discount2.setFlat(true);
+        discount2.setFrequency(Frequency.DAILY);
+
+        discountList.add(discount2);
+
+        assertEquals(0.0f, estimate1.getDiscount(discountList));
+    }
+
 }


### PR DESCRIPTION
Added following tests:

- `testMatchingSubscriptionFrequency()`: If discount with matching Sub. Frequency will be counted
- `testNonmatchingSubscriptionFrequency()`: Makes sure that discount with non-matching Sub. Frequency will be ignored
- `testMultipleDiscountsSum()`: Makes sure that multiple qualifying discounts can be accumulated.

Also included bug fixes for `Estimate.getDiscount()` along the way. 